### PR TITLE
Rendering trailing image fix

### DIFF
--- a/core/MovementHandler.py
+++ b/core/MovementHandler.py
@@ -1,8 +1,6 @@
 from persistance.Storage import Storage
-from math import sin, cos, radians
-from entities import Asteroid, Bullet, Spaceship
 from datetime import datetime
-from core.utils.time_helper import _convert_timestamp_to_microseconds
+from core.utils.time_helper import convert_timestamp_to_microseconds
 
 
 class MovementHandler:
@@ -14,18 +12,15 @@ class MovementHandler:
         pass
 
     def calculate_new_positions(self, storage: Storage, current_time: datetime):
-        elapsed_time = (_convert_timestamp_to_microseconds(current_time) -
-                        _convert_timestamp_to_microseconds(self.last_time_recorded)) / self.reduction_factor
+        elapsed_time = (convert_timestamp_to_microseconds(current_time) -
+                        convert_timestamp_to_microseconds(self.last_time_recorded)) / self.reduction_factor
         self.last_time_recorded = current_time
 
         for asteroid in storage.get_all_asteroids():
-            asteroid.x = asteroid.x + cos(radians(asteroid.angle)) * asteroid.velocity * elapsed_time
-            asteroid.y = asteroid.y + sin(radians(asteroid.angle)) * asteroid.velocity * elapsed_time
+            asteroid.move(elapsed_time)
 
         for bullet in storage.get_all_bullets():
-            bullet.x = bullet.x + cos(radians(bullet.angle)) * bullet.velocity * elapsed_time
-            bullet.y = bullet.y + sin(radians(bullet.angle)) * bullet.velocity * elapsed_time
+            bullet.move(elapsed_time)
             
         for spacecraft in storage.get_all_spacecrafts():
-            spacecraft.x = spacecraft.x + cos(radians(spacecraft.angle)) * spacecraft.velocity * elapsed_time
-            spacecraft.y = spacecraft.y + sin(radians(spacecraft.angle)) * spacecraft.velocity * elapsed_time
+            spacecraft.move(elapsed_time)

--- a/core/Screen.py
+++ b/core/Screen.py
@@ -24,38 +24,10 @@ class Screen(QWidget):
     def render_storage(self, storage: Storage):
         # TODO: implement drawing with QPainter
         for asteroid in storage.get_all_asteroids():
-            self.draw_asteroid(asteroid)
+            asteroid.draw(self)
 
         for spaceship in storage.get_all_spacecrafts():
-            self.draw_spaceship(spaceship)
+            spaceship.draw(self)
 
         for bullet in storage.get_all_bullets():
-            self.draw_bullet(bullet)
-
-    def draw_asteroid(self, asteroid: Asteroid):
-        image = QImage(asteroid.img_abs_path)
-        label = QLabel(self)
-        label.setPixmap(QPixmap.fromImage(image))
-        label.move(asteroid.x, asteroid.y)
-        label.show()
-        '''
-        painter = QPainter()
-        painter.begin(self)
-        painter.setPen(QPen(Qt.black, 10, Qt.SolidLine))
-        painter.drawLine(100, 100, 110, 100)
-        painter.end()
-        '''
-
-    def draw_spaceship(self, spaceship: Spaceship):
-        image = QImage(spaceship.img_abs_path)
-        label = QLabel(self)
-        label.setPixmap(QPixmap.fromImage(image))
-        label.move(spaceship.x, spaceship.y)
-        label.show()
-
-    def draw_bullet(self, bullet: Bullet):
-        image = QImage(bullet.img_abs_path)
-        label = QLabel(self)
-        label.setPixmap(QPixmap.fromImage(image))
-        label.move(bullet.x, bullet.y)
-        label.show()
+            bullet.draw(self)

--- a/core/utils/asteroid_factory.py
+++ b/core/utils/asteroid_factory.py
@@ -1,19 +1,19 @@
 from random import randint
 from entities.Asteroid import Asteroid
 from core.utils.Enums import AsteroidSize
-from core.utils.image_helper import _get_full_image_path
+from core.utils.image_helper import get_full_image_path
 
 
 def create_asteroid(asteroid_type: AsteroidSize, x=0, y=0, velocity: float = 1, angle: float = 0) -> Asteroid:
     if asteroid_type == 0:
         return Asteroid(x=x, y=y, velocity=velocity, angle=angle, r=35, points=200,
-                        img_abs_path=_get_full_image_path("small_asteroid.png"))
+                        img_abs_path=get_full_image_path("small_asteroid.png"))
     if asteroid_type == 1:
         return Asteroid(x=x, y=y, velocity=velocity, angle=angle, r=52, points=150,
-                        img_abs_path=_get_full_image_path("medium_asteroid.png"),
+                        img_abs_path=get_full_image_path("medium_asteroid.png"),
                         divide_asteroid=_divide_medium_asteroid)
     return Asteroid(x=x, y=y, velocity=velocity, angle=angle, r=75, points=100,
-                    img_abs_path=_get_full_image_path("large_asteroid.png"), divide_asteroid=_divide_large_asteroid)
+                    img_abs_path=get_full_image_path("large_asteroid.png"), divide_asteroid=_divide_large_asteroid)
 
 
 def _divide_medium_asteroid(asteroid: Asteroid) -> list:

--- a/core/utils/bullet_factory.py
+++ b/core/utils/bullet_factory.py
@@ -1,18 +1,18 @@
 from entities.Bullet import Bullet
-from core.utils.image_helper import _get_full_image_path
+from core.utils.image_helper import get_full_image_path
 
 
 def create_bullet(player_id: str, color: str, x: int = 0, y: int = 0, velocity: float = 0,
                   angle: float = 0, r: int = 5):
     if color == 'red':
         return Bullet(x=x, y=y, velocity=velocity, angle=angle, r=r, player_id=player_id, color=color,
-                      img_abs_path=_get_full_image_path("bullet_red.png"))
+                      img_abs_path=get_full_image_path("bullet_red.png"))
     elif color == 'green':
         return Bullet(x=x, y=y, velocity=velocity, angle=angle, r=r, player_id=player_id, color=color,
-                      img_abs_path=_get_full_image_path("bullet_green.png"))
+                      img_abs_path=get_full_image_path("bullet_green.png"))
     elif color == 'yellow':
         return Bullet(x=x, y=y, velocity=velocity, angle=angle, r=r, player_id=player_id, color=color,
-                      img_abs_path=_get_full_image_path("bullet_yellow.png"))
+                      img_abs_path=get_full_image_path("bullet_yellow.png"))
     elif color == 'blue':
         return Bullet(x=x, y=y, velocity=velocity, angle=angle, r=r, player_id=player_id, color=color,
-                      img_abs_path=_get_full_image_path("bullet_blue.png"))
+                      img_abs_path=get_full_image_path("bullet_blue.png"))

--- a/core/utils/image_helper.py
+++ b/core/utils/image_helper.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 
 
-def _get_full_image_path(img_name: str) -> str:
+def get_full_image_path(img_name: str) -> str:
     script_dir = os.path.dirname(__file__)  # <-- absolute dir the script is in
     rel_path = "..\\Resources\\" + img_name
     abs_file_path = Path(os.path.join(script_dir, rel_path)).resolve()

--- a/core/utils/spaceship_factory.py
+++ b/core/utils/spaceship_factory.py
@@ -1,5 +1,5 @@
 from entities.Spaceship import Spaceship
-from core.utils.image_helper import _get_full_image_path
+from core.utils.image_helper import get_full_image_path
 
 
 def create_spaceship(spaceship_id: str, player_id: str, color: str, x: int = 100, y: int = 100,
@@ -7,16 +7,16 @@ def create_spaceship(spaceship_id: str, player_id: str, color: str, x: int = 100
     if color == 'red':
         return Spaceship(x=x, y=y, velocity=velocity, angle=angle, r=30, spaceship_id=spaceship_id,
                          player_id=player_id, color='red',
-                         img_abs_path=_get_full_image_path("spaceship_red.png"))
+                         img_abs_path=get_full_image_path("spaceship_red.png"))
     elif color == 'green':
         return Spaceship(x=x, y=y, velocity=velocity, angle=angle, r=30,
                          spaceship_id=spaceship_id, player_id=player_id, color='green',
-                         img_abs_path=_get_full_image_path("spaceship_green.png"))
+                         img_abs_path=get_full_image_path("spaceship_green.png"))
     elif color == 'yellow':
         return Spaceship(x=x, y=y, velocity=velocity, angle=angle, r=30,
                          spaceship_id=spaceship_id, player_id=player_id, color='yellow',
-                         img_abs_path=_get_full_image_path("spaceship_yellow.png"))
+                         img_abs_path=get_full_image_path("spaceship_yellow.png"))
     else:
         return Spaceship(x=x, y=y, velocity=velocity, angle=angle, r=30,
                          spaceship_id=spaceship_id, player_id=player_id, color='blue',
-                         img_abs_path=_get_full_image_path("spaceship_blue.png"))
+                         img_abs_path=get_full_image_path("spaceship_blue.png"))

--- a/core/utils/time_helper.py
+++ b/core/utils/time_helper.py
@@ -1,12 +1,12 @@
 from datetime import datetime
 
 
-def _get_current_time_in_microseconds():
+def get_current_time_in_microseconds():
     curr_time = datetime.now()
     return curr_time.hour * 3600000000 + curr_time.minute * 60000000 + curr_time.second * 1000000 \
-           + curr_time.microsecond
+        + curr_time.microsecond
 
 
-def _convert_timestamp_to_microseconds(timestamp: datetime):
+def convert_timestamp_to_microseconds(timestamp: datetime):
     return timestamp.hour * 3600000000 + timestamp.minute * 60000000 + timestamp.second * 1000000 \
-           + timestamp.microsecond
+        + timestamp.microsecond

--- a/entities/Asteroid.py
+++ b/entities/Asteroid.py
@@ -1,3 +1,7 @@
+from PyQt5.QtGui import QImage
+from PyQt5.QtGui import QPixmap
+from PyQt5.QtWidgets import QWidget, QLabel
+
 from entities.MovableCircle import MovableCircle
 
 
@@ -12,6 +16,15 @@ class Asteroid(MovableCircle):
         self.points = points
         self.img_abs_path = img_abs_path
         self._divide = divide_asteroid
+        self.image = QImage(self.img_abs_path)
+        self.label = None
 
     def divide(self):
         return self._divide(self)
+
+    def draw(self, screen: QWidget):
+        if self.label is None:
+            self.label = QLabel(screen)
+            self.label.setPixmap(QPixmap.fromImage(self.image))
+        self.label.move(self.x, self.y)
+        self.label.show()

--- a/entities/Bullet.py
+++ b/entities/Bullet.py
@@ -1,3 +1,7 @@
+from PyQt5.QtGui import QImage
+from PyQt5.QtGui import QPixmap
+from PyQt5.QtWidgets import QWidget, QLabel
+
 from entities.MovableCircle import MovableCircle
 
 
@@ -8,3 +12,12 @@ class Bullet(MovableCircle):
         self.color = color
         self.player_id = player_id
         self.img_abs_path = img_abs_path
+        self.image = QImage(self.img_abs_path)
+        self.label = None
+
+    def draw(self, screen: QWidget):
+        if self.label is None:
+            self.label = QLabel(screen)
+            self.label.setPixmap(QPixmap.fromImage(self.image))
+        self.label.move(self.x, self.y)
+        self.label.show()

--- a/entities/MovableCircle.py
+++ b/entities/MovableCircle.py
@@ -1,4 +1,5 @@
 from entities.MovableObject import MovableObject
+from math import sin, cos, radians
 
 
 class MovableCircle(MovableObject):
@@ -13,6 +14,10 @@ class MovableCircle(MovableObject):
     def is_off_screen(self, screen_width: int, screen_height: int):
         return (self.x + self.r) < 0 or (self.x - self.r) > screen_width or \
                (self.y + self.r) < 0 or (self.y - self.r) > screen_height
+
+    def move(self, elapsed_time: float):
+        self.x = self.x + cos(radians(self.angle)) * self.velocity * elapsed_time
+        self.y = self.y + sin(radians(self.angle)) * self.velocity * elapsed_time
 
     def accelerate(self):
         self.velocity = self.velocity + 0.1

--- a/entities/Spaceship.py
+++ b/entities/Spaceship.py
@@ -1,3 +1,7 @@
+from PyQt5.QtGui import QImage
+from PyQt5.QtGui import QPixmap
+from PyQt5.QtWidgets import QWidget, QLabel
+
 from entities.MovableCircle import MovableCircle
 
 
@@ -9,3 +13,12 @@ class Spaceship(MovableCircle):
         self.player_id = player_id
         self.color = color
         self.img_abs_path = img_abs_path
+        self.image = QImage(self.img_abs_path)
+        self.label = None
+
+    def draw(self, screen: QWidget):
+        if self.label is None:
+            self.label = QLabel(screen)
+            self.label.setPixmap(QPixmap.fromImage(self.image))
+        self.label.move(self.x, self.y)
+        self.label.show()


### PR DESCRIPTION
**Privremeno rešenje**

TODO: Potrebna refaktorizacija tako da se ne ponavlja .draw logika u svakoj komponenti putem copy-paste, već bi bilo korisno da se iskoristi naprimer decorator patern koji bi primio u konstruktoru objekat tipa MovableCircle kao i putanju do ikonice i onda bi "ukrasio" metode. Npr. 

```python
class DrawableDecorator:
	def __init__(self, circle: MovableCircle, img_abs_path: str):
		self.circle
		self.img_abs_path
		// ...
	def move(self, elapsed_time):
		self.circle.move(elapsed_time)
		self.label.move(self.circle.x, self.circle.y) 
	def rotate_left(self):
		self.circle.rotate_left(...)
		transform = QtGui.QTransform().rotate(self.angle)
        self.setPixmap(QtGui.QPixmap(self.image).transformed(transform))
	// ...
```

> Kod iznad je samo primer kako bi napomenuta klasa mogla da izgleda (implementacija može/treba biti drugačija)